### PR TITLE
Add support for multiple Usenet providers

### DIFF
--- a/backend/Clients/UsenetProviderConnectionAllocator.cs
+++ b/backend/Clients/UsenetProviderConnectionAllocator.cs
@@ -1,0 +1,162 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NzbWebDAV.Config;
+
+namespace NzbWebDAV.Clients;
+
+public sealed class UsenetProviderConnectionAllocator
+{
+    private readonly UsenetProviderConfig[] _providers;
+    private readonly int[] _liveConnections;
+    private readonly object _sync = new();
+    private int _nextIndex;
+
+    public UsenetProviderConnectionAllocator(IEnumerable<UsenetProviderConfig> providers)
+    {
+        _providers = providers?.ToArray() ?? throw new ArgumentNullException(nameof(providers));
+        if (_providers.Length == 0)
+        {
+            throw new ArgumentException("At least one usenet provider must be configured.", nameof(providers));
+        }
+
+        _liveConnections = new int[_providers.Length];
+    }
+
+    public int TotalConnections => _providers.Sum(provider => provider.Connections);
+
+    public ValueTask<INntpClient> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        int providerIndex;
+        UsenetProviderConfig provider;
+
+        lock (_sync)
+        {
+            providerIndex = ReserveProviderIndex();
+            provider = _providers[providerIndex];
+            _liveConnections[providerIndex]++;
+        }
+
+        return CreateProviderConnectionAsync(providerIndex, provider, cancellationToken);
+    }
+
+    private int ReserveProviderIndex()
+    {
+        for (var attempt = 0; attempt < _providers.Length; attempt++)
+        {
+            var index = (_nextIndex + attempt) % _providers.Length;
+            if (_liveConnections[index] < _providers[index].Connections)
+            {
+                _nextIndex = index + 1;
+                return index;
+            }
+        }
+
+        throw new InvalidOperationException("No available usenet provider capacity.");
+    }
+
+    private async ValueTask<INntpClient> CreateProviderConnectionAsync(
+        int providerIndex,
+        UsenetProviderConfig provider,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var connection = await UsenetStreamingClient.CreateNewConnection(
+                provider.Host,
+                provider.Port,
+                provider.UseSsl,
+                provider.User,
+                provider.Pass,
+                cancellationToken);
+
+            return new ProviderScopedNntpClient(connection, () => Release(providerIndex));
+        }
+        catch
+        {
+            Release(providerIndex);
+            throw;
+        }
+    }
+
+    private void Release(int providerIndex)
+    {
+        lock (_sync)
+        {
+            if (_liveConnections[providerIndex] > 0)
+            {
+                _liveConnections[providerIndex]--;
+            }
+        }
+    }
+
+    private sealed class ProviderScopedNntpClient : INntpClient
+    {
+        private readonly INntpClient _inner;
+        private readonly Action _onDispose;
+        private int _disposed;
+
+        public ProviderScopedNntpClient(INntpClient inner, Action onDispose)
+        {
+            _inner = inner;
+            _onDispose = onDispose;
+        }
+
+        public Task<bool> ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken)
+        {
+            return _inner.ConnectAsync(host, port, useSsl, cancellationToken);
+        }
+
+        public Task<bool> AuthenticateAsync(string user, string pass, CancellationToken cancellationToken)
+        {
+            return _inner.AuthenticateAsync(user, pass, cancellationToken);
+        }
+
+        public Task<Usenet.Nntp.Responses.NntpStatResponse> StatAsync(string segmentId, CancellationToken cancellationToken)
+        {
+            return _inner.StatAsync(segmentId, cancellationToken);
+        }
+
+        public Task<Streams.YencHeaderStream> GetSegmentStreamAsync(string segmentId, CancellationToken cancellationToken)
+        {
+            return _inner.GetSegmentStreamAsync(segmentId, cancellationToken);
+        }
+
+        public Task<Usenet.Yenc.YencHeader> GetSegmentYencHeaderAsync(string segmentId, CancellationToken cancellationToken)
+        {
+            return _inner.GetSegmentYencHeaderAsync(segmentId, cancellationToken);
+        }
+
+        public Task<long> GetFileSizeAsync(Usenet.Nzb.NzbFile file, CancellationToken cancellationToken)
+        {
+            return _inner.GetFileSizeAsync(file, cancellationToken);
+        }
+
+        public Task<Usenet.Nntp.Responses.NntpDateResponse> DateAsync(CancellationToken cancellationToken)
+        {
+            return _inner.DateAsync(cancellationToken);
+        }
+
+        public Task WaitForReady(CancellationToken cancellationToken)
+        {
+            return _inner.WaitForReady(cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
+            {
+                return;
+            }
+
+            try
+            {
+                _inner.Dispose();
+            }
+            finally
+            {
+                _onDispose();
+            }
+        }
+    }
+}

--- a/backend/Config/UsenetProviderConfig.cs
+++ b/backend/Config/UsenetProviderConfig.cs
@@ -1,0 +1,11 @@
+namespace NzbWebDAV.Config;
+
+public record UsenetProviderConfig(
+    string Name,
+    string Host,
+    int Port,
+    bool UseSsl,
+    string User,
+    string Pass,
+    int Connections
+);

--- a/backend/Database/Models/ConfigItem.cs
+++ b/backend/Database/Models/ConfigItem.cs
@@ -11,6 +11,7 @@ public class ConfigItem
         "usenet.port",
         "usenet.use-ssl",
         "usenet.connections",
+        "usenet.providers",
         "usenet.user",
         "usenet.pass",
         "webdav.user",

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -18,6 +18,7 @@ const defaultConfig = {
     "usenet.port": "",
     "usenet.use-ssl": "false",
     "usenet.connections": "",
+    "usenet.providers": "[]",
     "usenet.connections-per-stream": "",
     "usenet.user": "",
     "usenet.pass": "",

--- a/frontend/app/routes/settings/usenet/usenet.module.css
+++ b/frontend/app/routes/settings/usenet/usenet.module.css
@@ -1,10 +1,46 @@
+
 .container {
-    max-width:400px;
+    max-width: 540px;
     margin-bottom: 25px;
 }
 
 .form-group {
     margin-bottom: 12px;
+}
+
+.providersContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.providerCard {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    padding: 16px;
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.providerHeader {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.removeProviderButton {
+    align-self: center;
+    margin-top: 30px;
+}
+
+.addProviderButton {
+    margin-top: 12px;
+    margin-bottom: 12px;
+}
+
+.connectionsSummary {
+    margin-bottom: 12px;
+    font-style: italic;
 }
 
 .justify-right{

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -1,156 +1,434 @@
 import { Button, Form } from "react-bootstrap";
-import styles from "./usenet.module.css"
-import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import styles from "./usenet.module.css";
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type Dispatch,
+    type SetStateAction,
+} from "react";
 
 type UsenetSettingsProps = {
-    config: Record<string, string>
-    setNewConfig: Dispatch<SetStateAction<Record<string, string>>>
-    onReadyToSave: (isReadyToSave: boolean) => void
+    config: Record<string, string>;
+    setNewConfig: Dispatch<SetStateAction<Record<string, string>>>;
+    onReadyToSave: (isReadyToSave: boolean) => void;
+};
+
+type ProviderFormState = {
+    name: string;
+    host: string;
+    port: string;
+    useSsl: boolean;
+    user: string;
+    pass: string;
+    connections: string;
+};
+
+const blankProvider = (index: number): ProviderFormState => ({
+    name: `Provider ${index + 1}`,
+    host: "",
+    port: "",
+    useSsl: true,
+    user: "",
+    pass: "",
+    connections: "",
+});
+
+const providerHash = (provider: ProviderFormState) => [
+    provider.name,
+    provider.host,
+    provider.port,
+    provider.useSsl ? "true" : "false",
+    provider.user,
+    provider.pass,
+    provider.connections,
+].join("|");
+
+const parseProvidersFromConfig = (config: Record<string, string>): ProviderFormState[] => {
+    const providers: ProviderFormState[] = [];
+    const rawProviders = config["usenet.providers"];
+    if (rawProviders) {
+        try {
+            const parsed = JSON.parse(rawProviders);
+            if (Array.isArray(parsed)) {
+                parsed.forEach((value: any, index: number) => {
+                    providers.push({
+                        name: typeof value?.name === "string" && value.name.trim() !== ""
+                            ? value.name
+                            : `Provider ${index + 1}`,
+                        host: stringFromUnknown(value?.host),
+                        port: stringFromUnknown(value?.port),
+                        useSsl: parseBoolean(value?.useSsl),
+                        user: stringFromUnknown(value?.user),
+                        pass: stringFromUnknown(value?.pass),
+                        connections: stringFromUnknown(value?.connections),
+                    });
+                });
+            }
+        } catch {
+            /* ignore malformed provider JSON */
+        }
+    }
+
+    if (providers.length > 0) {
+        return providers;
+    }
+
+    return [
+        {
+            name: config["usenet.host"] ? "Primary" : "Provider 1",
+            host: config["usenet.host"] || "",
+            port: config["usenet.port"] || "",
+            useSsl: config["usenet.use-ssl"] === "true",
+            user: config["usenet.user"] || "",
+            pass: config["usenet.pass"] || "",
+            connections: config["usenet.connections"] || "",
+        },
+    ];
+};
+
+const stringFromUnknown = (value: unknown): string => {
+    if (value === null || value === undefined) {
+        return "";
+    }
+    if (typeof value === "string") {
+        return value;
+    }
+    if (typeof value === "number") {
+        return Number.isFinite(value) ? String(value) : "";
+    }
+    return "";
+};
+
+const parseBoolean = (value: unknown): boolean => {
+    if (typeof value === "boolean") {
+        return value;
+    }
+    if (typeof value === "string") {
+        return value.trim().toLowerCase() === "true";
+    }
+    return false;
+};
+
+const stringifyProviders = (providers: ProviderFormState[]): string =>
+    JSON.stringify(
+        providers.map(provider => ({
+            name: provider.name,
+            host: provider.host,
+            port: provider.port,
+            useSsl: provider.useSsl,
+            user: provider.user,
+            pass: provider.pass,
+            connections: provider.connections,
+        })),
+    );
+
+const computeTotalConnections = (providers: ProviderFormState[]): number =>
+    providers.reduce((sum, provider) => {
+        const connections = Number.parseInt(provider.connections, 10);
+        if (Number.isFinite(connections)) {
+            return sum + connections;
+        }
+        return sum;
+    }, 0);
+
+const validateProvider = (provider: ProviderFormState): string | null =>
+    !provider.host
+        ? "`Host` is required"
+        : !provider.port
+            ? "`Port` is required"
+            : !isPositiveInteger(provider.port)
+                ? "`Port` is invalid"
+                : !provider.user
+                    ? "`User` is required"
+                    : !provider.pass
+                        ? "`Pass` is required"
+                        : !provider.connections
+                            ? "`Max Connections` is required"
+                            : !isPositiveInteger(provider.connections)
+                                ? "`Max Connections` is invalid"
+                                : null;
+
+const getConnectionsPerStreamError = (
+    value: string,
+    totalConnections: number,
+): string | null => {
+    if (!value) {
+        return "`Connections Per Stream` is required";
+    }
+    if (!isPositiveInteger(value)) {
+        return "`Connections Per Stream` is invalid";
+    }
+    const perStream = Number(value);
+    if (totalConnections > 0 && perStream > totalConnections) {
+        return "`Connections Per Stream` is invalid";
+    }
+    return null;
 };
 
 export function UsenetSettings({ config, setNewConfig, onReadyToSave }: UsenetSettingsProps) {
-    const [isFetching, setIsFetching] = useState(false);
-    const [isConnectionSuccessful, setIsConnectionSuccessful] = useState(false);
-    const [testedConfig, setTestedConfig] = useState({});
-    const isChangedSinceLastTest = isUsenetSettingsUpdated(config, testedConfig);
+    const providers = useMemo(() => parseProvidersFromConfig(config), [config]);
+    const [testedProviders, setTestedProviders] = useState<Record<string, boolean>>({});
+    const [testingIndex, setTestingIndex] = useState<number | null>(null);
 
-    const TestButtonLabel = isFetching ? "Testing Connection..."
-        : !config["usenet.host"] ? "`Host` is required"
-        : !config["usenet.port"] ? "`Port` is required"
-        : !isPositiveInteger(config["usenet.port"]) ? "`Port` is invalid"
-        : !config["usenet.user"] ? "`User` is required"
-        : !config["usenet.pass"] ? "`Pass` is required"
-        : !config["usenet.connections"] ? "`Max Connections` is required"
-        : !config["usenet.connections-per-stream"] ? "`Connections Per Stream` is required"
-        : !isPositiveInteger(config["usenet.connections"]) ? "`Max Connections` is invalid"
-        : !config["usenet.connections-per-stream"] ? "`Connections Per Stream` is required"
-        : !isPositiveInteger(config["usenet.connections-per-stream"]) ? "`Connections Per Stream` is invalid"
-        : Number(config["usenet.connections-per-stream"]) > Number(config["usenet.connections"]) ? "`Connections Per Stream` is invalid"
-        : !isChangedSinceLastTest && isConnectionSuccessful ? "Connected ✅"
-        : !isChangedSinceLastTest && !isConnectionSuccessful ? "Test Connection ❌"
-        : "Test Connection";
-    const testButtonVariant = isFetching ? "secondary"
-        : TestButtonLabel === "Connected ✅" ? "success"
-        : TestButtonLabel.includes("Test Connection") ? "primary"
-        : "danger";
-    const IsTestButtonEnabled = TestButtonLabel == "Test Connection"
-                             || TestButtonLabel == "Test Connection ❌";
+    const totalConnections = useMemo(() => computeTotalConnections(providers), [providers]);
+    const connectionsPerStream = config["usenet.connections-per-stream"] || "";
+    const connectionsPerStreamError = useMemo(
+        () => getConnectionsPerStreamError(connectionsPerStream, totalConnections),
+        [connectionsPerStream, totalConnections],
+    );
 
-    const isReadyToSave = isConnectionSuccessful && !isChangedSinceLastTest;
     useEffect(() => {
-        onReadyToSave && onReadyToSave(isReadyToSave);
-    }, [isReadyToSave])
+        const allProvidersValid = providers.every(provider => validateProvider(provider) === null);
+        const allProvidersTested = providers.every(provider => testedProviders[providerHash(provider)] === true);
+        const isReady =
+            providers.length > 0 &&
+            allProvidersValid &&
+            allProvidersTested &&
+            !connectionsPerStreamError;
+        onReadyToSave(isReady);
+    }, [providers, testedProviders, connectionsPerStreamError, onReadyToSave]);
 
-    const onTestButtonClicked = useCallback(async () => {
-        setIsFetching(true);
-        const response = await fetch("/api/test-usenet-connection", {
-            method: "POST",
-            body: (() => {
-                const form = new FormData();
-                form.append("host", config["usenet.host"]);
-                form.append("port", config["usenet.port"]);
-                form.append("use-ssl", config["usenet.use-ssl"] || "false");
-                form.append("user", config["usenet.user"]);
-                form.append("pass", config["usenet.pass"]);
-                return form;
-            })()
-        });
-        const isConnectionSuccessful = response.ok && ((await response.json())?.connected === true);
-        setIsFetching(false);
-        setTestedConfig(config);
-        setIsConnectionSuccessful(isConnectionSuccessful);
-    }, [config, setIsFetching, setIsConnectionSuccessful]);
+    const applyProviders = useCallback((nextProviders: ProviderFormState[]) => {
+        const providersToSave = nextProviders.length > 0 ? nextProviders : [blankProvider(0)];
+        const serializedProviders = stringifyProviders(providersToSave);
+        const firstProvider = providersToSave[0];
+        const total = computeTotalConnections(providersToSave);
+
+        setNewConfig(prev => ({
+            ...prev,
+            "usenet.providers": serializedProviders,
+            "usenet.host": firstProvider.host,
+            "usenet.port": firstProvider.port,
+            "usenet.use-ssl": firstProvider.useSsl ? "true" : "false",
+            "usenet.user": firstProvider.user,
+            "usenet.pass": firstProvider.pass,
+            "usenet.connections": total > 0 ? String(total) : "",
+        }));
+    }, [setNewConfig]);
+
+    const updateProvider = useCallback((index: number, updates: Partial<ProviderFormState>) => {
+        const nextProviders = providers.map((provider, providerIndex) =>
+            providerIndex === index ? { ...provider, ...updates } : provider,
+        );
+        applyProviders(nextProviders);
+    }, [providers, applyProviders]);
+
+    const addProvider = useCallback(() => {
+        const nextProviders = [...providers, blankProvider(providers.length)];
+        applyProviders(nextProviders);
+    }, [providers, applyProviders]);
+
+    const removeProvider = useCallback((index: number) => {
+        const nextProviders = providers.filter((_, providerIndex) => providerIndex !== index);
+        applyProviders(nextProviders);
+    }, [providers, applyProviders]);
+
+    const onTestProvider = useCallback(async (index: number) => {
+        const provider = providers[index];
+        if (!provider) {
+            return;
+        }
+
+        const validationMessage = validateProvider(provider);
+        if (validationMessage) {
+            return;
+        }
+
+        const hash = providerHash(provider);
+        setTestingIndex(index);
+        try {
+            const form = new FormData();
+            form.append("host", provider.host);
+            form.append("port", provider.port);
+            form.append("use-ssl", provider.useSsl ? "true" : "false");
+            form.append("user", provider.user);
+            form.append("pass", provider.pass);
+
+            const response = await fetch("/api/test-usenet-connection", {
+                method: "POST",
+                body: form,
+            });
+            const success = response.ok && ((await response.json())?.connected === true);
+            setTestedProviders(prev => ({ ...prev, [hash]: success }));
+        } finally {
+            setTestingIndex(null);
+        }
+    }, [providers]);
 
     return (
         <div className={styles.container}>
+            <div className={styles.providersContainer}>
+                {providers.map((provider, index) => {
+                    const validationMessage = validateProvider(provider);
+                    const hash = providerHash(provider);
+                    const testStatus = testedProviders[hash];
+                    const isTesting = testingIndex === index;
 
-            <Form.Group className={styles["form-group"]}>
-                <Form.Label>Host</Form.Label>
-                <Form.Control
-                    type="text"
-                    className={styles.input}
-                    value={config["usenet.host"] || ""}
-                    onChange={e => setNewConfig({ ...config, "usenet.host": e.target.value })} />
-            </Form.Group>
+                    let testButtonLabel: string;
+                    if (isTesting) {
+                        testButtonLabel = "Testing Connection...";
+                    } else if (validationMessage) {
+                        testButtonLabel = validationMessage;
+                    } else if (testStatus === true) {
+                        testButtonLabel = "Connected ✅";
+                    } else if (testStatus === false) {
+                        testButtonLabel = "Test Connection ❌";
+                    } else {
+                        testButtonLabel = "Test Connection";
+                    }
 
-            <Form.Group className={styles["form-group"]}>
-                <Form.Label>Port</Form.Label>
-                <Form.Control
-                    type="text"
-                    className={styles.input}
-                    value={config["usenet.port"] || ""}
-                    onChange={e => setNewConfig({ ...config, "usenet.port": e.target.value })} />
-            </Form.Group>
+                    const testButtonVariant = isTesting
+                        ? "secondary"
+                        : testStatus === true
+                            ? "success"
+                            : testStatus === false
+                                ? "danger"
+                                : "primary";
 
-            <div className={styles["justify-right"]}>
-                <Form.Check
-                    type="checkbox"
-                    label={`Use SSL`}
-                    checked={config["usenet.use-ssl"] === "true"}
-                    onChange={e => setNewConfig({ ...config, "usenet.use-ssl": "" + e.target.checked })} />
+                    const isTestEnabled = !validationMessage && !isTesting;
+
+                    return (
+                        <div key={`${index}-${provider.name}`} className={styles.providerCard}>
+                            <div className={styles.providerHeader}>
+                                <Form.Group className={styles["form-group"]}>
+                                    <Form.Label>Display Name</Form.Label>
+                                    <Form.Control
+                                        type="text"
+                                        value={provider.name}
+                                        onChange={event => updateProvider(index, { name: event.target.value })}
+                                    />
+                                </Form.Group>
+                                {providers.length > 1 && (
+                                    <Button
+                                        variant="outline-danger"
+                                        size="sm"
+                                        onClick={() => removeProvider(index)}
+                                        className={styles.removeProviderButton}
+                                    >
+                                        Remove
+                                    </Button>
+                                )}
+                            </div>
+
+                            <Form.Group className={styles["form-group"]}>
+                                <Form.Label>Host</Form.Label>
+                                <Form.Control
+                                    type="text"
+                                    className={styles.input}
+                                    value={provider.host}
+                                    onChange={event => updateProvider(index, { host: event.target.value })}
+                                />
+                            </Form.Group>
+
+                            <Form.Group className={styles["form-group"]}>
+                                <Form.Label>Port</Form.Label>
+                                <Form.Control
+                                    type="text"
+                                    className={styles.input}
+                                    value={provider.port}
+                                    onChange={event => updateProvider(index, { port: event.target.value })}
+                                />
+                            </Form.Group>
+
+                            <div className={styles["justify-right"]}>
+                                <Form.Check
+                                    type="checkbox"
+                                    label="Use SSL"
+                                    checked={provider.useSsl}
+                                    onChange={event => updateProvider(index, { useSsl: Boolean(event.target.checked) })}
+                                />
+                            </div>
+
+                            <Form.Group className={styles["form-group"]}>
+                                <Form.Label>User</Form.Label>
+                                <Form.Control
+                                    type="text"
+                                    className={styles.input}
+                                    value={provider.user}
+                                    onChange={event => updateProvider(index, { user: event.target.value })}
+                                />
+                            </Form.Group>
+
+                            <Form.Group className={styles["form-group"]}>
+                                <Form.Label>Pass</Form.Label>
+                                <Form.Control
+                                    type="password"
+                                    className={styles.input}
+                                    value={provider.pass}
+                                    onChange={event => updateProvider(index, { pass: event.target.value })}
+                                />
+                            </Form.Group>
+
+                            <Form.Group className={styles["form-group"]}>
+                                <Form.Label>Max Connections</Form.Label>
+                                <Form.Control
+                                    type="text"
+                                    className={styles.input}
+                                    value={provider.connections}
+                                    onChange={event => updateProvider(index, { connections: event.target.value })}
+                                />
+                            </Form.Group>
+
+                            <div className={styles["justify-right"]}>
+                                <Button
+                                    className={styles["test-connection-button"]}
+                                    variant={testButtonVariant}
+                                    disabled={!isTestEnabled}
+                                    onClick={() => onTestProvider(index)}
+                                >
+                                    {testButtonLabel}
+                                </Button>
+                            </div>
+                        </div>
+                    );
+                })}
             </div>
 
-            <br />
+            <Button
+                variant="outline-primary"
+                className={styles.addProviderButton}
+                onClick={addProvider}
+            >
+                Add Provider
+            </Button>
 
-            <Form.Group className={styles["form-group"]}>
-                <Form.Label>User</Form.Label>
-                <Form.Control
-                    type="text"
-                    className={styles.input}
-                    value={config["usenet.user"] || ""}
-                    onChange={e => setNewConfig({ ...config, "usenet.user": e.target.value })} />
-            </Form.Group>
-
-            <Form.Group className={styles["form-group"]}>
-                <Form.Label>Pass</Form.Label>
-                <Form.Control
-                    className={styles.input}
-                    type="password"
-                    value={config["usenet.pass"] || ""}
-                    onChange={e => setNewConfig({ ...config, "usenet.pass": e.target.value })} />
-            </Form.Group>
-
-            <Form.Group className={styles["form-group"]}>
-                <Form.Label>Max Connections</Form.Label>
-                <Form.Control
-                    className={styles.input}
-                    type="text"
-                    placeholder="50"
-                    value={config["usenet.connections"] || ""}
-                    onChange={e => setNewConfig({ ...config, "usenet.connections": e.target.value })} />
-            </Form.Group>
+            <div className={styles.connectionsSummary}>
+                Total Max Connections: {totalConnections || 0}
+            </div>
 
             <Form.Group className={styles["form-group"]}>
                 <Form.Label>Connections Per Stream</Form.Label>
                 <Form.Control
                     className={styles.input}
                     type="text"
-                    placeholder="5"
-                    value={config["usenet.connections-per-stream"] || ""}
-                    onChange={e => setNewConfig({ ...config, "usenet.connections-per-stream": e.target.value })} />
+                    value={connectionsPerStream}
+                    isInvalid={Boolean(connectionsPerStreamError)}
+                    onChange={event => setNewConfig(prev => ({
+                        ...prev,
+                        "usenet.connections-per-stream": event.target.value,
+                    }))}
+                />
+                {connectionsPerStreamError && (
+                    <Form.Control.Feedback type="invalid">
+                        {connectionsPerStreamError}
+                    </Form.Control.Feedback>
+                )}
             </Form.Group>
-
-            <div className={styles["justify-right"]}>
-                <Button
-                    className={styles["test-connection-button"]}
-                    variant={testButtonVariant}
-                    disabled={!IsTestButtonEnabled}
-                    onClick={() => onTestButtonClicked()}>
-                    {TestButtonLabel}
-                </Button>
-            </div>
         </div>
     );
 }
 
 export function isUsenetSettingsUpdated(config: Record<string, string>, newConfig: Record<string, string>) {
-    return config["usenet.host"] !== newConfig["usenet.host"]
+    return config["usenet.providers"] !== newConfig["usenet.providers"]
+        || config["usenet.host"] !== newConfig["usenet.host"]
         || config["usenet.port"] !== newConfig["usenet.port"]
         || config["usenet.use-ssl"] !== newConfig["usenet.use-ssl"]
         || config["usenet.user"] !== newConfig["usenet.user"]
         || config["usenet.pass"] !== newConfig["usenet.pass"]
         || config["usenet.connections"] !== newConfig["usenet.connections"]
-        || config["usenet.connections-per-stream"] !== newConfig["usenet.connections-per-stream"]
+        || config["usenet.connections-per-stream"] !== newConfig["usenet.connections-per-stream"];
 }
 
 export function isPositiveInteger(value: string) {


### PR DESCRIPTION
## Summary
- add configuration parsing and connection allocation for multiple Usenet providers
- update the Usenet streaming client to balance connections across configured providers
- expand the settings UI to manage multiple providers, including per-provider testing and validation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6feff06f88332a2044781a07bd868